### PR TITLE
security(sync): remove hardcoded OAuth secret, restrict token file to 0600

### DIFF
--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -11,9 +11,12 @@ use oauth2::reqwest::async_http_client;
 use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
 
-// Google OAuth credentials - Users need to create their own at https://console.cloud.google.com
-const GOOGLE_CLIENT_ID: &str = "787652804555-akmgh2mr0kdif7hafo43rhnso0q1ds4f.apps.googleusercontent.com";
-const GOOGLE_CLIENT_SECRET: &str = "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";
+// Google OAuth credentials, supplied at build time. Never hardcode these:
+// a desktop binary cannot keep a secret, so anything embedded here is public.
+// Set THINKUTILS_GOOGLE_CLIENT_ID / _SECRET when building to enable sync.
+// Create credentials at https://console.cloud.google.com (APIs & Services > Credentials).
+const GOOGLE_CLIENT_ID: Option<&str> = option_env!("THINKUTILS_GOOGLE_CLIENT_ID");
+const GOOGLE_CLIENT_SECRET: Option<&str> = option_env!("THINKUTILS_GOOGLE_CLIENT_SECRET");
 const REDIRECT_URI: &str = "http://localhost:8765/callback";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -137,15 +140,54 @@ fn save_sync_state(state: &SyncState) -> Result<(), String> {
     let content = serde_json::to_string_pretty(state)
         .map_err(|e| format!("Failed to serialize sync state: {}", e))?;
     
-    fs::write(&path, content)
-        .map_err(|e| format!("Failed to write sync state: {}", e))?;
-    
+    write_private(&path, &content)
+}
+
+/// Write a file readable only by its owner.
+///
+/// The sync state holds OAuth access and refresh tokens, so it must never be
+/// left at the default umask where other local users can read it.
+fn write_private(path: &std::path::Path, content: &str) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| format!("Failed to write sync state: {}", e))?;
+        file.write_all(content.as_bytes())
+            .map_err(|e| format!("Failed to write sync state: {}", e))?;
+
+        // .mode() only applies when the file is created, so a file that already
+        // existed at 0644 would keep those bits. Tighten it explicitly.
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("Failed to secure sync state: {}", e))?;
+    }
+
+    #[cfg(not(unix))]
+    fs::write(path, content).map_err(|e| format!("Failed to write sync state: {}", e))?;
+
     Ok(())
 }
 
 fn create_oauth_client() -> Result<BasicClient, String> {
-    let client_id = ClientId::new(GOOGLE_CLIENT_ID.to_string());
-    let client_secret = ClientSecret::new(GOOGLE_CLIENT_SECRET.to_string());
+    let client_id = ClientId::new(
+        GOOGLE_CLIENT_ID
+            .filter(|s| !s.is_empty())
+            .ok_or("Google sync is not configured in this build (THINKUTILS_GOOGLE_CLIENT_ID unset).")?
+            .to_string(),
+    );
+    let client_secret = ClientSecret::new(
+        GOOGLE_CLIENT_SECRET
+            .filter(|s| !s.is_empty())
+            .ok_or("Google sync is not configured in this build (THINKUTILS_GOOGLE_CLIENT_SECRET unset).")?
+            .to_string(),
+    );
     let auth_url = AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_string())
         .map_err(|e| format!("Invalid auth URL: {}", e))?;
     let token_url = TokenUrl::new("https://oauth2.googleapis.com/token".to_string())
@@ -577,5 +619,57 @@ pub fn save_settings(settings: UserSettings) -> ApiResponse<String> {
             data: None,
             error: Some(format!("Failed to load current state: {}", e)),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unique temp path per call; std has no tempdir and we don't want a dev-dependency
+    /// for two tests.
+    fn temp_path(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!("thinkutils_test_{}_{}_{}", tag, std::process::id(), nanos))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_creates_owner_only_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("create");
+        write_private(&path, "{\"token\":\"secret\"}").expect("write should succeed");
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {:o}", mode);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{\"token\":\"secret\"}");
+
+        let _ = fs::remove_file(&path);
+    }
+
+    /// The regression this guards: OpenOptions::mode() only applies at creation, so a
+    /// sync_state.json already on disk at 0644 (as shipped before this fix) would keep
+    /// its world-readable bits and continue leaking tokens.
+    #[cfg(unix)]
+    #[test]
+    fn write_private_tightens_existing_world_readable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("tighten");
+        fs::write(&path, "old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o644);
+
+        write_private(&path, "new").expect("write should succeed");
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "pre-existing file was not tightened; got {:o}", mode);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new");
+
+        let _ = fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Leaked credential

The Google client secret was committed in the initial commit (`95a07ec`) and has been public in this repo ever since. A desktop binary cannot keep a secret, so credentials are now supplied at build time via `option_env!`.

**The exposed client has already been deleted in Google Cloud Console**, so the leaked secret is inert — it authenticates a client that no longer exists (verified: Google returns `401 deleted_client`). It remains in git history; no rewrite is needed given the client is gone.

## Token file permissions

`~/.config/thinkutils/sync_state.json` held OAuth access and refresh tokens at the default umask — observed `-rw-rw-r--`, world-readable. Writes now go through `write_private()`.

The subtle part: `OpenOptions::mode()` only takes effect **when the file is created**. A `sync_state.json` already on disk at 0644 — which is every existing install — would keep its bits and keep leaking. So the mode is re-applied explicitly after the write.

## Behaviour change

Google sync is disabled in builds without `THINKUTILS_GOOGLE_CLIENT_ID`/`_SECRET`, with a clear error rather than a silent failure. Sync is already broken on v0.1.10 regardless, since the client it points at was deleted — restoring it (with PKCE, no secret) is tracked separately.

## Tests
- `write_private_creates_owner_only_file` — asserts 0600 on create
- `write_private_tightens_existing_world_readable_file` — creates a 0644 file first, proves it gets tightened. This is the regression that would otherwise leave every existing install exposed.

Full suite: 19 passing.