### PR TITLE
security(mcp): reject wildcard bind, loopback only

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -30,9 +30,17 @@ fn validate_battery_thresholds(start: u32, stop: u32) -> Option<String> {
     }
 }
 
+/// Loopback only. `0.0.0.0` is deliberately rejected: this server exposes fan and
+/// battery control with no authentication, so binding it to a routable interface
+/// hands hardware control to anyone on the network.
+///
+/// Note this does NOT close the DNS-rebinding / cross-origin CSRF vector against
+/// loopback — a malicious page can still POST to 127.0.0.1 from the user's browser.
+/// Closing that needs Host+Origin allowlisting, which rmcp 0.1.5 gives us no seam
+/// to add (SseServer::serve_with_config builds its router internally). See task #1.
 fn validate_mcp_host(host: &str) -> Option<String> {
-    if host != "127.0.0.1" && host != "0.0.0.0" && host != "localhost" {
-        Some("Host must be 127.0.0.1, 0.0.0.0, or localhost".into())
+    if host != "127.0.0.1" && host != "localhost" {
+        Some("Host must be 127.0.0.1 or localhost. Binding to other interfaces is not allowed: the MCP server is unauthenticated.".into())
     } else {
         None
     }
@@ -402,7 +410,6 @@ mod tests {
     #[test]
     fn valid_mcp_hosts() {
         assert!(validate_mcp_host("127.0.0.1").is_none());
-        assert!(validate_mcp_host("0.0.0.0").is_none());
         assert!(validate_mcp_host("localhost").is_none());
     }
 
@@ -411,6 +418,14 @@ mod tests {
         for host in &["192.168.1.1", "10.0.0.1", "example.com", ""] {
             assert!(validate_mcp_host(host).is_some(), "expected '{}' to be rejected", host);
         }
+    }
+
+    /// The MCP server is unauthenticated and exposes fan/battery control, so it
+    /// must never be bindable to a routable interface. Regression guard.
+    #[test]
+    fn wildcard_bind_is_rejected() {
+        assert!(validate_mcp_host("0.0.0.0").is_some());
+        assert!(validate_mcp_host("::").is_some());
     }
 
     // -- Bind host resolution --


### PR DESCRIPTION
## The change

`validate_mcp_host` accepted `0.0.0.0`, so the MCP server could be bound to a routable interface. That server is **unauthenticated** and exposes `set_fan_speed` and `set_battery_thresholds` — anyone on the network could set the fan to `0`, which is a thermal-damage vector, not just a nuisance.

Only `127.0.0.1` and `localhost` are accepted now. No docs referenced the wildcard, so nothing else needed updating.

## On the rmcp advisory

`cargo audit` flags `rmcp` 0.1.5 for [RUSTSEC-2026-0189](https://rustsec.org/advisories/RUSTSEC-2026-0189) (DNS rebinding, CVSS 8.8). Worth being precise: that advisory covers the **Streamable HTTP** transport, and this app uses the **SSE** transport. It's flagged on version, not reachability.

The underlying weakness is real regardless, and it lives in our code rather than the dependency: there is no `Host` or `Origin` validation anywhere. Per the [related dynoxide advisory](https://github.com/nubo-db/dynoxide/security/advisories/GHSA-fvh2-gm75-j4j7), a `Host` check alone is insufficient — a page can `fetch` the loopback endpoint with `mode: 'no-cors'` and the `Origin` goes unchecked.

## What this does NOT close

⚠️ A malicious page you visit can **still** POST to `127.0.0.1:8765/message` and invoke tools. This PR closes network exposure, not the loopback CSRF vector.

Closing that needs Host+Origin allowlisting, and rmcp 0.1.5 offers no seam: `SseServer::serve_with_config` builds its axum router and binds the listener internally, and `App` is private — there is no middleware hook. That needs rmcp >= 1.4 (which ships `allowed_hosts`/`allowed_origins`), tracked separately.

Until then, leaving the MCP server stopped when not in use is the safest posture.

## Test

`wildcard_bind_is_rejected` guards both `0.0.0.0` and `::`. Full suite: 19 passing.