### PR TITLE
docs: repair line continuations in dependency install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ sudo apt install build-essential \
     file \
     git \
     libayatana-appindicator3-dev \
-    librsvg2-dev
+    librsvg2-dev \
     libssl-dev \
     libwebkit2gtk-4.1-dev \
     npm \
@@ -202,16 +202,16 @@ sudo apt install build-essential \
 
 **Fedora:**
 ```bash
-sudo dnf install curl \
+sudo dnf install cargo \
+    curl \
     file \
-    libappindicator-gtk3-devel \
-    librsvg2-devel
-    openssl-devel \
-    wget \
-    cargo \ 
     git \
+    libappindicator-gtk3-devel \
+    librsvg2-devel \
     npm \
-    webkit2gtk4.1-devel
+    openssl-devel \
+    webkit2gtk4.1-devel \
+    wget
 ```
 
 ### Getting Started


### PR DESCRIPTION
Follow-up to #11 by @M4rk3h.

The intent of that PR was right and is kept as-is — adding `git`, `npm`, `cargo`, and correcting `cd thinkutils` → `cd ThinkUtils` (which fixed a genuine papercut).

Two backslashes went missing in the merge, which silently split each install into **two commands**:

```
sudo apt install build-essential ... librsvg2-dev
libssl-dev libwebkit2gtk-4.1-dev npm wget
```

The second line runs on its own, so users get `libssl-dev: command not found` and an install missing **libwebkit2gtk-4.1-dev** — the one dependency the build can't proceed without.

The Fedora block had the same missing backslash after `librsvg2-devel`, plus a trailing space after `cargo \` — which breaks continuation just as effectively, since the backslash must be the final character on the line. That one is genuinely easy to miss in review.

Fedora list also alphabetised to match Debian.

### Verification
Executed both blocks with the install command stubbed out; each now parses as exactly one command.