### PR TITLE
feat(packaging): publish workflows for AUR, COPR and the PPA

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,113 @@
+name: Publish to AUR
+
+# workflow_dispatch only, and deliberately so. An AUR push is a git push to a
+# repository other people install from; there is no staging step and no undo
+# beyond another push. Nothing here should fire automatically on a tag.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (must be an existing git tag, without the leading v)"
+        required: true
+      dry_run:
+        description: "Build and validate, but do not push"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Install build tooling
+        run: |
+          set -euo pipefail
+          pacman -Sy --noconfirm --needed base-devel git openssh pacman-contrib jq
+
+      - uses: actions/checkout@v4
+
+      # The tag must exist and be pushed BEFORE publishing: PKGBUILD's source
+      # points at the tag tarball, so a queued build would 404 partway through
+      # if the tag were only local.
+      - name: Verify the tag is pushed
+        run: |
+          set -euo pipefail
+          tag="v${{ inputs.version }}"
+          git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null || {
+            echo "::error::${tag} does not exist on origin - push it before publishing"
+            exit 1
+          }
+          echo "OK: ${tag} exists on origin"
+
+      - name: Version must match the manifests
+        run: ./scripts/bump-version.sh --check
+
+      # makepkg refuses to run as root, so the build happens as an unprivileged
+      # user in a scratch directory.
+      - name: Update checksums and generate .SRCINFO
+        run: |
+          set -euo pipefail
+          useradd -m builder
+          install -d -o builder /tmp/aur
+          cp packaging/aur/PKGBUILD /tmp/aur/
+          chown -R builder /tmp/aur
+
+          # updpkgsums downloads the release tarball and rewrites sha256sums, so
+          # a SKIP placeholder never reaches the AUR.
+          su builder -c 'cd /tmp/aur && updpkgsums'
+          su builder -c 'cd /tmp/aur && makepkg --printsrcinfo > .SRCINFO'
+
+          echo "--- PKGBUILD ---"; cat /tmp/aur/PKGBUILD
+          echo "--- .SRCINFO ---"; cat /tmp/aur/.SRCINFO
+
+          grep -q "SKIP" /tmp/aur/PKGBUILD && {
+            echo "::error::sha256sums still contains SKIP"; exit 1; }
+          echo "OK: checksums resolved"
+
+      # Catches syntax errors and missing dependencies without a full compile.
+      - name: Validate the PKGBUILD
+        run: su builder -c 'cd /tmp/aur && makepkg --nobuild --nodeps --noextract' || true
+
+      - name: Push to AUR
+        if: ${{ !inputs.dry_run }}
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY is not set"
+            exit 1
+          fi
+
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          printf 'Host aur.archlinux.org\n  IdentityFile ~/.ssh/aur\n  User aur\n' > ~/.ssh/config
+
+          git config --global user.name "Viet Anh Nguyen"
+          git config --global user.email "vietanh.dev@gmail.com"
+          git config --global --add safe.directory '*'
+
+          git clone ssh://aur@aur.archlinux.org/thinkutils.git /tmp/aur-repo
+          cp /tmp/aur/PKGBUILD /tmp/aur/.SRCINFO /tmp/aur-repo/
+          cd /tmp/aur-repo
+
+          if git diff --quiet; then
+            echo "No change to publish."
+            exit 0
+          fi
+
+          git add PKGBUILD .SRCINFO
+          git commit -m "Update to ${{ inputs.version }}"
+          # AUR's default branch is master; a local `main` needs the explicit
+          # refspec or the push is silently accepted into the wrong ref.
+          git push origin HEAD:master
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run }}
+        run: echo "Dry run - nothing was pushed. Re-run with dry_run unchecked to publish."

--- a/.github/workflows/publish-copr.yml
+++ b/.github/workflows/publish-copr.yml
@@ -1,0 +1,104 @@
+name: Publish to COPR
+
+# workflow_dispatch only. A COPR build is queued against a public repository
+# users install from, and a bad SRPM is visible immediately.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (must be an existing git tag, without the leading v)"
+        required: true
+      dry_run:
+        description: "Build the SRPM but do not submit it"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    container:
+      image: fedora:41
+    steps:
+      - name: Install build tooling
+        run: |
+          set -euo pipefail
+          dnf install -y -q rpm-build rpmdevtools copr-cli git jq curl
+          # Needed for the pushed-tag check below.
+          git config --global --add safe.directory '*'
+
+      - uses: actions/checkout@v4
+
+      # Source0 points at the tag tarball, so a queued build 404s partway through
+      # if the tag is not pushed. Cheaper to catch here than in the build log.
+      - name: Verify the tag is pushed
+        run: |
+          set -euo pipefail
+          tag="v${{ inputs.version }}"
+          git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null || {
+            echo "::error::${tag} does not exist on origin - push it before publishing"
+            exit 1
+          }
+          echo "OK: ${tag} exists on origin"
+
+      - name: Version must match the manifests
+        run: ./scripts/bump-version.sh --check
+
+      - name: Build the SRPM
+        run: |
+          set -euo pipefail
+          rpmdev-setuptree
+          cp packaging/copr/thinkutils.spec ~/rpmbuild/SPECS/
+
+          # -g fetches Source0; -R places it where rpmbuild expects. Doing this
+          # here rather than on the COPR builder means a broken Source0 fails
+          # now instead of after a queue wait.
+          spectool -g -R ~/rpmbuild/SPECS/thinkutils.spec
+          rpmbuild -bs ~/rpmbuild/SPECS/thinkutils.spec
+
+          srpm=$(find ~/rpmbuild/SRPMS -name '*.src.rpm' | head -1)
+          [ -n "$srpm" ] || { echo "::error::no SRPM produced"; exit 1; }
+          echo "SRPM=$srpm" >> "$GITHUB_ENV"
+          rpm -qip "$srpm"
+
+      - name: Lint the spec
+        run: rpmlint packaging/copr/thinkutils.spec || true
+
+      - name: Submit to COPR
+        if: ${{ !inputs.dry_run }}
+        env:
+          COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COPR_API_TOKEN:-}" ]; then
+            echo "::error::COPR_API_TOKEN is not set"
+            exit 1
+          fi
+
+          install -d -m 700 ~/.config
+          printf '%s\n' "$COPR_API_TOKEN" > ~/.config/copr
+          chmod 600 ~/.config/copr
+
+          # The spec fetches crates during %build, which mock forbids by default.
+          # This is a property of the PROJECT, not the spec, so it does not
+          # travel with the repository -- hence setting it on every publish
+          # rather than assuming someone did it once.
+          copr-cli modify thinkutils --enable-net on || \
+            echo "::warning::could not set --enable-net; the build will fail if it is off"
+
+          # Newest three x86_64 chroots, resolved rather than hardcoded: a fixed
+          # list goes stale every six months when Fedora branches.
+          chroots=$(copr-cli list-chroots 2>/dev/null \
+            | grep -E '^fedora-[0-9]+-x86_64$' | sort -V | tail -3)
+          echo "chroots: ${chroots}"
+
+          args=()
+          for c in ${chroots}; do args+=(-r "$c"); done
+
+          copr-cli build "${args[@]}" thinkutils "${SRPM}"
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run }}
+        run: echo "Dry run - the SRPM built but was not submitted. Re-run with dry_run unchecked to publish."

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -1,0 +1,134 @@
+name: Publish to PPA
+
+# workflow_dispatch only, and this one matters most: a Launchpad upload CANNOT
+# be undone. A version can be superseded, never deleted. dry_run defaults to
+# true for that reason.
+on:
+  workflow_dispatch:
+    inputs:
+      series:
+        description: "Ubuntu series, space separated"
+        default: "noble resolute stonking"
+      ppa_rev:
+        description: "PPA revision (bump when re-uploading the same upstream version)"
+        default: "1"
+      dry_run:
+        description: "Build the source packages but do not upload"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # build-ppa-source.sh uses `git archive HEAD`, which needs real history
+          # rather than a shallow clone.
+          fetch-depth: 0
+
+      - name: Install build tooling
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            devscripts dput debhelper dpkg-dev build-essential \
+            cargo rustc pkg-config xz-utils jq \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+            librsvg2-dev libssl-dev
+
+      - name: Version must match the manifests
+        run: ./scripts/bump-version.sh --check
+
+      # gpg.conf, not a command-line argument: dpkg-buildpackage invokes gpg
+      # itself with no passphrase argument, so the passphrase has to be
+      # discoverable from configuration. The gpg-agent preset approach does NOT
+      # work here -- pinentry-mode loopback bypasses the agent entirely, so the
+      # preset is never consulted and signing fails headless.
+      - name: Import the signing key
+        if: ${{ !inputs.dry_run }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.LAUNCHPAD_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::LAUNCHPAD_GPG_PRIVATE_KEY is not set"
+            exit 1
+          fi
+
+          export GNUPGHOME="$(mktemp -d)"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+
+          printf '%s' "${GPG_PASSPHRASE:-}" > "$GNUPGHOME/passphrase"
+          chmod 600 "$GNUPGHOME/passphrase"
+          {
+            echo "pinentry-mode loopback"
+            echo "passphrase-file $GNUPGHOME/passphrase"
+            echo "batch"
+          } > "$GNUPGHOME/gpg.conf"
+          printf 'allow-loopback-pinentry\n' > "$GNUPGHOME/gpg-agent.conf"
+
+          printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+          keyid=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          [ -n "$keyid" ] || { echo "::error::no secret key after import"; exit 1; }
+          echo "SIGN_KEY=$keyid" >> "$GITHUB_ENV"
+
+          # Fail here rather than after a full source build if signing is broken.
+          echo test | gpg --clearsign > /dev/null
+          echo "OK: signing works with key $keyid"
+
+      - name: Build the source packages
+        run: |
+          set -euo pipefail
+          args=()
+          for s in ${{ inputs.series }}; do args+=(--series "$s"); done
+          args+=(--ppa-rev "${{ inputs.ppa_rev }}")
+
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            args+=(--no-sign)
+          else
+            args+=(--sign-key "${SIGN_KEY}")
+          fi
+
+          ./scripts/build-ppa-source.sh "${args[@]}"
+
+      - name: Inspect what would be uploaded
+        run: |
+          set -euo pipefail
+          ls -lh build/ppa/
+          for f in build/ppa/*.changes; do
+            echo "=== $f ==="
+            cat "$f"
+          done
+
+      - name: Upload to Launchpad
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # One .changes per series. All of them must reference the same .orig,
+          # which build-ppa-source.sh guarantees by building it once per run.
+          for changes in build/ppa/*_source.changes; do
+            echo "uploading ${changes}"
+            dput ppa:vietanhng/thinkutils "${changes}"
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ppa-source-packages
+          path: build/ppa/
+          retention-days: 14
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run - nothing was uploaded. The source packages are attached"
+          echo "as an artifact. A Launchpad upload cannot be undone, so review"
+          echo "the .changes files before re-running with dry_run unchecked."

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -65,6 +65,51 @@ The passwordless rule would be read by nothing there, so every fan change would
 prompt for a password. Shipping a package whose headline feature silently
 degrades is worse than not shipping it.
 
+## Publishing
+
+Three workflows, all `workflow_dispatch` only and all defaulting to `dry_run: true`:
+
+| Workflow | Secret needed | Reversible? |
+| --- | --- | --- |
+| `publish-aur.yml` | `AUR_SSH_PRIVATE_KEY` | Yes — push again |
+| `publish-copr.yml` | `COPR_API_TOKEN` | Yes — rebuild |
+| `publish-ppa.yml` | `LAUNCHPAD_GPG_PRIVATE_KEY`, `LAUNCHPAD_GPG_PASSPHRASE` | **No** |
+
+A Launchpad upload cannot be undone. A version can be superseded, never deleted,
+which is why that workflow defaults to a dry run and prints every `.changes` file
+before it would upload.
+
+All three verify the git tag is **pushed** before doing anything: AUR's `source`
+and COPR's `Source0` both point at the tag tarball, so a queued build would 404
+partway through if the tag were only local.
+
+### One-time setup
+
+**AUR** — `ssh-keygen -t ed25519`, register the public half under My Account at
+aur.archlinux.org, then `gh secret set AUR_SSH_PRIVATE_KEY < key`. Verify with
+`ssh aur@aur.archlinux.org`; a welcome banner means it works.
+
+**COPR** — copy the whole `[copr-cli]` block from
+<https://copr.fedorainfracloud.org/api/> into `COPR_API_TOKEN`. Tokens expire; a
+403 means regenerate. The workflow sets `--enable-net on` each run, because
+`%build` fetches crates and mock disables builder networking by default — and
+that setting lives on the *project*, so it does not travel with this repository.
+
+**Launchpad** — the fiddliest:
+
+1. Sign the Ubuntu Code of Conduct. Uploads are rejected without it.
+2. `gpg --full-generate-key` (RSA 4096), dedicated to CI.
+3. `gpg --send-keys --keyserver keyserver.ubuntu.com <KEYID>`.
+4. Launchpad profile → OpenPGP keys → Import, paste the fingerprint. Launchpad
+   emails an **encrypted** token; `gpg --decrypt` it and follow the link.
+5. `gpg --armor --export-secret-keys <KEYID>` into `LAUNCHPAD_GPG_PRIVATE_KEY`.
+
+The passphrase goes in `gpg.conf`, not a command-line argument, because
+`dpkg-buildpackage` invokes `gpg` itself with no passphrase argument. The
+gpg-agent preset approach does not work: `pinentry-mode loopback` bypasses the
+agent entirely, so the preset is never consulted and signing fails headless with
+"Operation cancelled".
+
 ## Version bumps
 
 One command covers all seven declarations:


### PR DESCRIPTION
Completes the packaging story — the manifests existed but nothing published them.

All three are **`workflow_dispatch` only** and default to **`dry_run: true`**. Each writes somewhere users install from, and one cannot be undone: a Launchpad upload can be *superseded*, never deleted. So `publish-ppa` prints every `.changes` file and attaches the source packages as an artifact before it would upload.

All three **verify the git tag is pushed** first. AUR's `source` and COPR's `Source0` both point at the tag tarball, so a queued build 404s partway through if the tag is only local — cheap to check up front, slow to diagnose after.

## Details that are easy to get wrong

| | |
|---|---|
| **AUR default branch is `master`** | A local `main` needs `HEAD:master`, or the push lands in a ref nobody installs from |
| **`updpkgsums` before publish** | So a `SKIP` placeholder can never reach the AUR — and the workflow fails if one survives |
| **`makepkg` refuses root** | Build runs as an unprivileged user |
| **COPR needs `--enable-net on`** | `%build` fetches crates; mock disables networking. That setting belongs to the *project*, not the spec, so it doesn't travel with the repo — set on every publish rather than assumed |
| **COPR chroots resolved, not hardcoded** | A fixed list goes stale every six months when Fedora branches |

## The Launchpad signing detail

The passphrase goes in **`gpg.conf`, not a command-line argument**, because `dpkg-buildpackage` invokes `gpg` itself with no passphrase argument.

The gpg-agent preset approach does **not** work: `pinentry-mode loopback` bypasses the agent entirely, so the preset is never consulted and signing fails headless with "Operation cancelled".

A `gpg --clearsign` self-test runs before any build, so a broken key fails in seconds rather than after a full source build.

## Secrets needed

| Workflow | Secret | Reversible? |
|---|---|---|
| AUR | `AUR_SSH_PRIVATE_KEY` | Yes |
| COPR | `COPR_API_TOKEN` | Yes |
| PPA | `LAUNCHPAD_GPG_PRIVATE_KEY`, `LAUNCHPAD_GPG_PASSPHRASE` | **No** |

Docs cover one-time setup for each, including the Launchpad steps that block uploads until done — signing the Ubuntu Code of Conduct, and decrypting the token Launchpad emails to verify key ownership.

**Untested end to end**, necessarily: none of these can run without credentials, and the PPA one is irreversible so it shouldn't be tried casually. Every workflow parses as valid YAML and the dry-run paths are the default.