### PR TITLE
fix: three defects around offline CPUs and a blocked UI thread

### DIFF
--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -81,18 +81,33 @@ pub struct ApiResponse<T> {
     pub error: Option<String>,
 }
 
+/// Collecting stats blocks: it sleeps 200ms between the two `/proc/stat`
+/// samples it has to diff, and shells out to `df` and `ps aux`.
+///
+/// A non-async `#[tauri::command]` runs inline on the IPC thread, so this used
+/// to hard-block the UI. The Monitor view polls every 2s, which meant ≥200ms of
+/// stall out of every 2000ms — a visible ~10% duty cycle of dropped frames in
+/// scrolling, hover, and window dragging for as long as that view was open.
+///
+/// spawn_blocking moves the whole collection onto the blocking pool rather than
+/// just converting the sleep, since the two subprocesses block as well.
 #[tauri::command]
-pub fn get_system_monitor() -> ApiResponse<SystemMonitor> {
-    match collect_system_stats() {
-        Ok(monitor) => ApiResponse {
+pub async fn get_system_monitor() -> ApiResponse<SystemMonitor> {
+    match tokio::task::spawn_blocking(collect_system_stats).await {
+        Ok(Ok(monitor)) => ApiResponse {
             success: true,
             data: Some(monitor),
             error: None,
         },
-        Err(e) => ApiResponse {
+        Ok(Err(e)) => ApiResponse {
             success: false,
             data: None,
             error: Some(e),
+        },
+        Err(e) => ApiResponse {
+            success: false,
+            data: None,
+            error: Some(format!("Monitor collection failed to run: {}", e)),
         },
     }
 }
@@ -126,19 +141,19 @@ fn get_cpu_stats() -> Result<CpuStats, String> {
     // Calculate usage from deltas
     let total_usage = calculate_cpu_usage_from_snapshots(&snapshot1.total, &snapshot2.total);
 
+    // Match the two snapshots by kernel core id rather than by position. A CPU
+    // going offline between the two 200ms-apart reads shifts every later entry,
+    // which would otherwise diff one core's counters against another's and
+    // produce nonsense usage figures.
     let mut cores = Vec::new();
-    for (i, (core1, core2)) in snapshot1
-        .cores
-        .iter()
-        .zip(snapshot2.cores.iter())
-        .enumerate()
-    {
-        let usage = calculate_cpu_usage_from_snapshots(core1, core2);
-        let freq = get_core_frequency(i);
+    for (id, core1) in &snapshot1.cores {
+        let Some((_, core2)) = snapshot2.cores.iter().find(|(id2, _)| id2 == id) else {
+            continue;
+        };
         cores.push(CoreStats {
-            core_id: i,
-            usage_percent: usage,
-            frequency: freq,
+            core_id: *id,
+            usage_percent: calculate_cpu_usage_from_snapshots(core1, core2),
+            frequency: get_core_frequency(*id),
         });
     }
 
@@ -154,7 +169,9 @@ fn get_cpu_stats() -> Result<CpuStats, String> {
 #[derive(Debug)]
 struct CpuSnapshot {
     total: CpuTimes,
-    cores: Vec<CpuTimes>,
+    /// `(kernel core id, times)`. The id is carried rather than implied by
+    /// position because /proc/stat skips offline CPUs.
+    cores: Vec<(usize, CpuTimes)>,
 }
 
 #[derive(Debug)]
@@ -177,15 +194,20 @@ fn parse_cpu_snapshot(stat: &str) -> Result<CpuSnapshot, String> {
         if line.starts_with("cpu ") {
             total = Some(parse_cpu_line(line)?);
         } else if line.starts_with("cpu") && line.len() > 3 {
-            if let Some(core_id) = line.strip_prefix("cpu") {
-                if core_id
+            if let Some(rest) = line.strip_prefix("cpu") {
+                // Keep the id the kernel reported. It used to be parsed only to
+                // check it was numeric and then discarded, with the caller's
+                // Vec index standing in for it. /proc/stat omits offline CPUs
+                // entirely, so on a machine with cpu5 offline every core after
+                // the gap was labelled one too low and its frequency was read
+                // from the wrong (offline) CPU, showing 0 MHz.
+                if let Ok(id) = rest
                     .split_whitespace()
                     .next()
                     .unwrap_or("")
                     .parse::<usize>()
-                    .is_ok()
                 {
-                    cores.push(parse_cpu_line(line)?);
+                    cores.push((id, parse_cpu_line(line)?));
                 }
             }
         }
@@ -438,4 +460,62 @@ fn get_total_memory_mb() -> f64 {
                 })
         })
         .unwrap_or(8192.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A realistic /proc/stat with cpu5 offline. The kernel omits offline CPUs
+    /// entirely rather than reporting them as idle, so the numbering has a hole.
+    const STAT_WITH_CPU5_OFFLINE: &str = "\
+cpu  100 0 50 900 0 0 0 0
+cpu0 10 0 5 90 0 0 0 0
+cpu1 10 0 5 90 0 0 0 0
+cpu2 10 0 5 90 0 0 0 0
+cpu3 10 0 5 90 0 0 0 0
+cpu4 10 0 5 90 0 0 0 0
+cpu6 10 0 5 90 0 0 0 0
+cpu7 10 0 5 90 0 0 0 0
+intr 12345
+ctxt 67890
+";
+
+    /// The regression: core ids came from the Vec index, so everything after the
+    /// gap was labelled one too low — cpu6 reported as core 5, cpu7 as core 6 —
+    /// and each read its frequency from the wrong CPU. Index 5 pointed at the
+    /// offline cpu5, which has no cpufreq directory, so it showed 0 MHz.
+    #[test]
+    fn offline_cpus_do_not_shift_core_ids() {
+        let snap = parse_cpu_snapshot(STAT_WITH_CPU5_OFFLINE).expect("parses");
+
+        let ids: Vec<usize> = snap.cores.iter().map(|(id, _)| *id).collect();
+        assert_eq!(
+            ids,
+            vec![0, 1, 2, 3, 4, 6, 7],
+            "ids must be the kernel's, not positions in the vector"
+        );
+        assert!(
+            !ids.contains(&5),
+            "cpu5 is offline and absent from /proc/stat"
+        );
+    }
+
+    /// The `cpu ` aggregate line must not be counted as a core, or the machine
+    /// reports one more core than it has.
+    #[test]
+    fn the_aggregate_line_is_not_a_core() {
+        let snap = parse_cpu_snapshot(STAT_WITH_CPU5_OFFLINE).expect("parses");
+        assert_eq!(snap.cores.len(), 7, "seven online CPUs, not eight");
+        assert_eq!(snap.total.user, 100, "aggregate parsed into total");
+    }
+
+    /// Non-cpu lines sit between and after the cpu lines in a real /proc/stat.
+    #[test]
+    fn unrelated_lines_are_ignored() {
+        let snap = parse_cpu_snapshot(STAT_WITH_CPU5_OFFLINE).expect("parses");
+        for (id, _) in &snap.cores {
+            assert!(*id < 8, "parsed a bogus core id {}", id);
+        }
+    }
 }

--- a/src-tauri/src/performance.rs
+++ b/src-tauri/src/performance.rs
@@ -95,6 +95,51 @@ fn validate_governor(governor: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Where the per-CPU governor files live. A glob, not a count, so it is the
+/// root shell that decides which CPUs exist — see [`governor_script`].
+const CPU_GLOB: &str = "/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor";
+
+/// Build the script that applies `governor` to every CPU exposing a governor file.
+///
+/// The previous version counted `cpuN` directories and emitted one fixed
+/// redirect per index under `set -e`. That broke in two ways: the count includes
+/// CPUs that are present but OFFLINE, whose `cpufreq/` directory the kernel
+/// removes, and it assumes contiguous numbering. Offlining a core — disabling
+/// SMT, say — made that index's redirect fail with ENOENT, `set -e` aborted, and
+/// pkexec returned non-zero *after* the earlier cores had already been changed.
+/// The machine was left with mixed governors while the UI said nothing happened.
+///
+/// Globbing defers the decision to execution time, as root, so it sees whatever
+/// CPUs are online at that moment. Only a total failure is an error: one core
+/// going offline mid-run must not discard the ones that were set.
+///
+/// `governor` is validated against the kernel's own list before it gets here,
+/// so interpolating it is safe.
+fn governor_script(governor: &str, glob: &str) -> String {
+    format!(
+        r#"#!/bin/bash
+set -u
+applied=0
+failed=0
+for f in {glob}; do
+  [ -e "$f" ] || continue
+  if echo {governor} > "$f" 2>/dev/null; then
+    applied=$((applied + 1))
+  else
+    failed=$((failed + 1))
+    echo "could not write $f" >&2
+  fi
+done
+echo "governor applied to $applied CPU(s), $failed refused"
+if [ "$applied" -eq 0 ]; then
+  echo "no CPU accepted the governor" >&2
+  exit 1
+fi
+exit 0
+"#
+    )
+}
+
 #[tauri::command]
 pub async fn set_cpu_governor(governor: String) -> ApiResponse<String> {
     println!("[Performance] Setting CPU governor to: {}", governor);
@@ -109,35 +154,8 @@ pub async fn set_cpu_governor(governor: String) -> ApiResponse<String> {
         };
     }
 
-    // Get number of CPUs
-    let cpu_count = fs::read_dir("/sys/devices/system/cpu")
-        .ok()
-        .map(|entries| {
-            entries
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.file_name().to_string_lossy().starts_with("cpu")
-                        && e.file_name().to_string_lossy()[3..]
-                            .chars()
-                            .all(|c| c.is_numeric())
-                })
-                .count()
-        })
-        .unwrap_or(1);
-
-    println!("[Performance] Found {} CPU cores", cpu_count);
-
-    // Create script to set governor for all CPUs
     let temp_script = format!("/tmp/set_governor_{}.sh", std::process::id());
-    let mut script_content = String::from("#!/bin/bash\nset -e\n");
-
-    for i in 0..cpu_count {
-        script_content.push_str(&format!(
-            "echo {} > /sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor\n",
-            governor, i
-        ));
-    }
-    script_content.push_str("exit 0\n");
+    let script_content = governor_script(&governor, CPU_GLOB);
 
     println!("[Performance] Script content:\n{}", script_content);
 
@@ -457,6 +475,172 @@ pub async fn set_turbo_boost(enabled: bool) -> ApiResponse<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a fake CPU tree and actually run the generated script against it.
+    ///
+    /// `online` lists the CPU indices that get a `cpufreq/scaling_governor`;
+    /// any index in `present` but not `online` gets a bare `cpuN` directory,
+    /// which is exactly what the kernel leaves behind for an offline CPU.
+    fn run_governor_script(present: &[u32], online: &[u32]) -> (bool, String, Vec<(u32, String)>) {
+        let root = std::env::temp_dir().join(format!(
+            "thinkutils_gov_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        for cpu in present {
+            let dir = root.join(format!("cpu{}", cpu));
+            if online.contains(cpu) {
+                let freq = dir.join("cpufreq");
+                fs::create_dir_all(&freq).unwrap();
+                fs::write(freq.join("scaling_governor"), "powersave\n").unwrap();
+            } else {
+                fs::create_dir_all(&dir).unwrap();
+            }
+        }
+
+        let glob = format!("{}/cpu[0-9]*/cpufreq/scaling_governor", root.display());
+        let script = governor_script("performance", &glob);
+
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("bash runs");
+
+        let mut written = Vec::new();
+        for cpu in online {
+            let p = root
+                .join(format!("cpu{}", cpu))
+                .join("cpufreq/scaling_governor");
+            if let Ok(v) = fs::read_to_string(&p) {
+                written.push((*cpu, v.trim().to_string()));
+            }
+        }
+
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let _ = fs::remove_dir_all(&root);
+        (out.status.success(), combined, written)
+    }
+
+    /// The regression: cpu5 offline used to abort the whole script under set -e,
+    /// after cpu0..cpu4 had already been changed — mixed governors, and a UI
+    /// saying the operation failed.
+    #[test]
+    fn an_offline_cpu_does_not_abort_the_others() {
+        let (ok, output, written) = run_governor_script(&[0, 1, 2, 3, 4, 5], &[0, 1, 2, 3, 4]);
+
+        assert!(
+            ok,
+            "script should succeed despite cpu5 being offline:\n{output}"
+        );
+        assert_eq!(written.len(), 5, "every online CPU should be written");
+        for (cpu, value) in &written {
+            assert_eq!(value, "performance", "cpu{} kept the old governor", cpu);
+        }
+        assert!(
+            output.contains("applied to 5 CPU(s)"),
+            "should report what it actually did:\n{output}"
+        );
+    }
+
+    /// Numbering is not guaranteed contiguous, and indexing 0..count assumed it.
+    #[test]
+    fn non_contiguous_cpu_numbering_is_handled() {
+        let (ok, output, written) = run_governor_script(&[0, 3, 7], &[0, 3, 7]);
+
+        assert!(ok, "gaps in numbering are normal:\n{output}");
+        assert_eq!(written.len(), 3, "cpu0, cpu3 and cpu7 should all be set");
+    }
+
+    /// An existing-but-unwritable governor file is the case `set -e` actually
+    /// aborted on, so exercise it directly: one refusal must not cost the rest.
+    #[cfg(unix)]
+    #[test]
+    fn one_refused_write_does_not_discard_the_successful_ones() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "thinkutils_gov_ro_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        for cpu in 0..3u32 {
+            let freq = root.join(format!("cpu{}", cpu)).join("cpufreq");
+            fs::create_dir_all(&freq).unwrap();
+            let f = freq.join("scaling_governor");
+            fs::write(&f, "powersave\n").unwrap();
+            if cpu == 1 {
+                fs::set_permissions(&f, fs::Permissions::from_mode(0o444)).unwrap();
+            }
+        }
+
+        let glob = format!("{}/cpu[0-9]*/cpufreq/scaling_governor", root.display());
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(governor_script("performance", &glob))
+            .output()
+            .expect("bash runs");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let read = |cpu: u32| {
+            fs::read_to_string(
+                root.join(format!("cpu{}", cpu))
+                    .join("cpufreq/scaling_governor"),
+            )
+            .unwrap()
+            .trim()
+            .to_string()
+        };
+
+        // Root can write through 0444, which would make this assert nothing.
+        if read(1) == "performance" {
+            let _ = fs::remove_dir_all(&root);
+            eprintln!("skipping: running as root, 0444 is not enforced");
+            return;
+        }
+
+        assert!(
+            out.status.success(),
+            "one unwritable CPU must not fail the whole operation:\n{combined}"
+        );
+        assert_eq!(read(0), "performance", "cpu0 should have been set");
+        assert_eq!(read(2), "performance", "cpu2 should have been set");
+        assert!(
+            combined.contains("applied to 2 CPU(s), 1 refused"),
+            "should report the partial result honestly:\n{combined}"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Failing silently would be worse than failing loudly: the UI would report
+    /// a governor change that never touched anything.
+    #[test]
+    fn no_writable_cpu_at_all_is_still_an_error() {
+        let (ok, output, _) = run_governor_script(&[0, 1], &[]);
+
+        assert!(!ok, "a total failure must surface:\n{output}");
+        assert!(
+            output.contains("no CPU accepted the governor"),
+            "should say why:\n{output}"
+        );
+    }
 
     #[test]
     fn accepts_plain_governor_names() {


### PR DESCRIPTION
Three independent runtime defects found while auditing the backend. All three are invisible in normal operation on a machine with every core online.

## 1. The Monitor view blocks the UI thread ~10% of the time

`get_system_monitor` was a **non-async** `#[tauri::command]`. Tauri's default is `ExecutionContext::Blocking`, so the body runs inline on the IPC thread — not on the async runtime.

That body sleeps 200ms between the two `/proc/stat` samples it has to diff, and additionally shells out to `df` and `ps aux` synchronously. `monitor.js` polls every 2s.

So for as long as the Monitor view is open, the main thread is hard-blocked for ≥200ms out of every 2000ms — a visible duty cycle of dropped frames in scrolling, hover states, and window dragging.

`spawn_blocking` moves the whole collection off, subprocesses included, rather than just converting the sleep.

## 2. Setting the CPU governor fails wholesale if any CPU is offline

The old script counted `cpuN` directories, then emitted a bare redirect per index `0..count` under `set -e`. Two bad assumptions: the count includes CPUs that are **present but offline** — whose `cpufreq/` directory the kernel removes — and the numbering is assumed contiguous.

Disable SMT (`echo 0 > .../cpu5/online`) and the redirect for `cpu5` fails with ENOENT, `set -e` aborts, pkexec returns non-zero — *after* cpu0–cpu4 were already changed. Mixed governors, and a UI saying the operation failed.

Now globs at execution time (as root, so it sees whatever is online at that moment) and treats only a total failure as an error.

## 3. Per-core stats are shifted past an offline CPU

`parse_cpu_snapshot` parsed each core id purely to check it was numeric, then discarded it and let the caller's `enumerate()` index stand in.

`/proc/stat` omits offline CPUs entirely. With cpu5 offline the file lists cpu0–4, cpu6, cpu7 — so vector index 5 is really cpu6. Every core past the gap was labelled one too low and read its frequency from the wrong CPU. Index 5 pointed at the offline cpu5, which has no cpufreq directory: 0 MHz.

The id is now carried through, and the two snapshots are matched **by id rather than by position**, so a CPU going offline between the two 200ms-apart reads can't diff one core's counters against another's.

## Verification

104 tests, clippy clean.

The governor tests are checked against the genuine original implementation rather than a paraphrase — restoring it fails all four:

```
one_refused_write_does_not_discard_the_successful_ones ... FAILED
no_writable_cpu_at_all_is_still_an_error ... FAILED
non_contiguous_cpu_numbering_is_handled ... FAILED
an_offline_cpu_does_not_abort_the_others ... FAILED
```

Worth recording: an earlier mutation that only re-added `set -e` **passed**, because bash suppresses errexit inside an `if` condition. The original's bare redirects were what made it fire — so the weaker mutation proved nothing, and the test needed the real thing to be trustworthy.