### PR TITLE
docs(apt): say plainly what [trusted=yes] gives up

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -43,6 +43,7 @@ export default withMermaid(
             items: [
               { text: 'Architecture', link: '/development/architecture' },
               { text: 'Packaging', link: '/development/packaging' },
+              { text: 'APT Signing', link: '/development/apt-signing' },
               { text: 'CSS Architecture', link: '/development/css' },
               { text: 'Icon Generation', link: '/development/icons' },
               {

--- a/docs/download.md
+++ b/docs/download.md
@@ -120,6 +120,22 @@ sudo apt update
 sudo apt install thinkutils
 ```
 
+::: warning What `[trusted=yes]` means
+This repository is not yet GPG-signed, and `[trusted=yes]` tells `apt` to install
+from it without verifying any signature. HTTPS still authenticates the server for
+the duration of the download, but nothing proves the packages are the ones our CI
+built — and ThinkUtils installs a helper that runs as root.
+
+If that trade-off is not one you want to make, download the `.deb` from the
+[releases page](https://github.com/vietanhdev/ThinkUtils/releases) and install it
+with `apt install ./thinkutils_*.deb` instead. You give up automatic updates and
+check for new versions yourself.
+
+Signing is implemented and waiting on a key — see
+[apt-signing](/development/apt-signing). Once it is enabled these instructions
+change to `signed-by=` and the `[trusted=yes]` flag goes away.
+:::
+
 ## Before fan control works
 
 One step is not optional, and it is the most common reason people think the app


### PR DESCRIPTION
The download page hands users `[trusted=yes]` — which disables apt's signature verification entirely — next to a package that installs a root-invoked fan helper, with no indication that either fact is true.

Follow-up to #35, which added the signing machinery. Until a key is configured the repository really is unsigned, so the flag is still *correct*; it just shouldn't be silent.

- States what the flag actually does
- Offers the manual `.deb` path for anyone unwilling to take that trade (giving up automatic updates)
- Links to the signing doc
- Adds `apt-signing` to the Development sidebar — it shipped in #35 but was reachable only by knowing the URL

The instructions revert to `signed-by=` on their own once a key exists: the release workflow generates that page from whichever form it actually published, so there's no second place to remember to update.

Docs build passes (vitepress fails on dead links, so the new sidebar link resolves).