### PR TITLE
docs(apt): signing key is configured; show the verified install path

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -121,20 +121,43 @@ sudo apt install thinkutils
 ```
 
 ::: warning What `[trusted=yes]` means
-This repository is not yet GPG-signed, and `[trusted=yes]` tells `apt` to install
-from it without verifying any signature. HTTPS still authenticates the server for
-the duration of the download, but nothing proves the packages are the ones our CI
-built — and ThinkUtils installs a helper that runs as root.
+`[trusted=yes]` tells `apt` to install without verifying any signature. HTTPS
+still authenticates the server for the duration of the download, but nothing
+proves the packages are the ones our CI built — and ThinkUtils installs a helper
+that runs as root.
 
-If that trade-off is not one you want to make, download the `.deb` from the
-[releases page](https://github.com/vietanhdev/ThinkUtils/releases) and install it
-with `apt install ./thinkutils_*.deb` instead. You give up automatic updates and
-check for new versions yourself.
+It is needed because the **currently published** repository is unsigned. A
+signing key is now configured, so the next release will publish a signed
+repository and these instructions change to the ones below.
 
-Signing is implemented and waiting on a key — see
-[apt-signing](/development/apt-signing). Once it is enabled these instructions
-change to `signed-by=` and the `[trusted=yes]` flag goes away.
+If you would rather not take that trade in the meantime, download the `.deb`
+from the [releases page](https://github.com/vietanhdev/ThinkUtils/releases) and
+install it with `apt install ./thinkutils_*.deb`. You give up automatic updates
+and check for new versions yourself.
 :::
+
+### From the next release: verified installs
+
+Once a signed release is published, `https://gh.vietanh.dev/ThinkUtils/apt` will
+carry `InRelease`, `Release.gpg`, and the public key. Switch to:
+
+```bash
+curl -fsSL https://gh.vietanh.dev/ThinkUtils/apt/thinkutils-archive-keyring.asc \
+  | sudo gpg --dearmor -o /usr/share/keyrings/thinkutils-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/thinkutils-archive-keyring.gpg] https://gh.vietanh.dev/ThinkUtils/apt ./" \
+  | sudo tee /etc/apt/sources.list.d/thinkutils.list
+
+sudo apt update
+sudo apt install thinkutils
+```
+
+`signed-by=` scopes the key to this one repository, so it cannot vouch for
+packages from anywhere else in your sources. The repository's own index page
+always shows whichever form is currently published — it is generated from what
+the release actually produced, so it cannot disagree with reality.
+
+Maintainers: see [apt-signing](/development/apt-signing).
 
 ## Before fan control works
 


### PR DESCRIPTION
A GPG signing key is now configured as `APT_GPG_PRIVATE_KEY` / `APT_GPG_PASSPHRASE`, so the next tagged release will publish a **signed** APT repository and the generated index page will switch to `signed-by=`.

`docs/download.md` (from #39) says the repo is unsigned and will stay that way until a key exists. That becomes wrong at the next release.

## The awkward part, handled explicitly

The *currently published* repository is still unsigned — signing only takes effect when a release actually runs. So `[trusted=yes]` remains the instruction that works today and keeps its warning. The `signed-by=` commands are shown below it, clearly marked as taking effect from the next release, rather than replacing instructions that would not work yet.

The repository's own `index.html` is generated from whichever form the release actually published, so it cannot drift from reality. This page now says so.

## Verification

Before writing any of this I extracted the `Update APT repository` step's shell from the **merged** workflow on main and ran it against the real signing key:

```
signed the Release file with 665B0501813B5351
PASS: detached sig verifies vs published key
PASS: InRelease verifies vs published key
PASS: tampered Release rejected
... 18/18
```

That verifies against the published public key alone — which is what a user's `apt` does — so the claim that the next release produces a working signed repo is tested, not assumed.

Docs build passes.