### PR TITLE
fix(aur): make host-key setup deterministic and diagnosable

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -95,11 +95,32 @@ jobs:
             exit 1
           fi
 
-          install -d -m 700 ~/.ssh
-          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
-          chmod 600 ~/.ssh/aur
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
-          printf 'Host aur.archlinux.org\n  IdentityFile ~/.ssh/aur\n  User aur\n' > ~/.ssh/config
+          # Absolute paths and an explicit GIT_SSH_COMMAND, rather than ~/.ssh
+          # plus a config file. The shell and the ssh that git spawns each
+          # resolve ~ from HOME independently, and in a container that is one
+          # more thing that can silently differ -- the failure then arrives as
+          # "Host key verification failed", which points at the host key rather
+          # than at path resolution.
+          key=/tmp/aur_id
+          hosts=/tmp/aur_known_hosts
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$key"
+          chmod 600 "$key"
+
+          # AUR is reached over SSH, so its host key has to be known before git
+          # will connect. ssh-keyscan can return NOTHING and still exit 0, and
+          # the previous 2>/dev/null hid why -- so assert the result instead of
+          # assuming it.
+          ssh-keyscan -t rsa,ecdsa,ed25519 aur.archlinux.org > "$hosts" 2>/tmp/keyscan.err || true
+          if [ ! -s "$hosts" ]; then
+            echo "::error::ssh-keyscan returned no host keys for aur.archlinux.org - cannot verify the host to push to"
+            cat /tmp/keyscan.err >&2 || true
+            exit 1
+          fi
+          echo "host keys fetched: $(wc -l < "$hosts")"
+
+          # IdentitiesOnly stops ssh offering any other key it happens to find
+          # and being rejected before it reaches this one.
+          export GIT_SSH_COMMAND="ssh -i ${key} -o IdentitiesOnly=yes -o UserKnownHostsFile=${hosts} -o StrictHostKeyChecking=yes"
 
           git config --global user.name "Viet Anh Nguyen"
           git config --global user.email "vietanh.dev@gmail.com"


### PR DESCRIPTION
The AUR publish for v0.2.0 failed:

```
Cloning into '/tmp/aur-repo'...
Host key verification failed.
fatal: Could not read from remote repository.
```

Publishing to the AUR is a `git push` over SSH, so `aur.archlinux.org`'s host key must be in `known_hosts` before git will connect.

## Why it failed silently

The step already ran `ssh-keyscan` — but with `2>/dev/null`. `ssh-keyscan` can return **nothing while still exiting 0**, so an empty result passed the `set -e` check and surfaced three lines later as an error about the *host key*, rather than about the scan that produced no keys.

That's the same shape as several bugs found this session: a step that can succeed while accomplishing nothing, where the eventual error names the wrong cause.

## Changes

- **Assert the scan produced something**, and print the count. An empty result now fails at the point it happens, naming the actual cause.
- **Absolute paths + explicit `GIT_SSH_COMMAND`**, replacing `~/.ssh` and a config file. The shell and the `ssh` that git spawns each resolve `~` from `HOME` independently, and in a container that's one more thing that can quietly differ — another route to exactly this error while the host key was never the problem.
- **`IdentitiesOnly=yes`** so ssh doesn't offer some other key and get rejected before reaching ours.
- **`StrictHostKeyChecking=yes`** retained — the point is to verify the host, not to skip verifying it.

## Context

The key itself is known-good: I verified it authenticates as `vietanhdev` against `aur.archlinux.org` before setting the secret, and the dry run passed every step (`Push to AUR` is the one step a dry run skips).

Three of four channels are already live for v0.2.0 — GitHub release, the signed APT repo, and COPR (both arches). AUR is the last one.