### PR TITLE
fix(aur): first publish of a new package pushed nothing, and reported success

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -130,16 +130,38 @@ jobs:
           cp /tmp/aur/PKGBUILD /tmp/aur/.SRCINFO /tmp/aur-repo/
           cd /tmp/aur-repo
 
-          if git diff --quiet; then
+          # Stage FIRST, then ask whether anything is staged.
+          #
+          # `git diff --quiet` before staging compares tracked files only, so on
+          # a brand-new AUR package -- an empty repo, where PKGBUILD and .SRCINFO
+          # are untracked -- it sees no change, prints "No change to publish" and
+          # exits 0. The workflow then reports success having pushed nothing,
+          # which is precisely what happened on the first v0.2.0 publish: green
+          # run, 404 package.
+          #
+          # git status --porcelain counts untracked and staged entries, and works
+          # in a repo with no HEAD to diff against.
+          git add PKGBUILD .SRCINFO
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No change to publish."
             exit 0
           fi
 
-          git add PKGBUILD .SRCINFO
           git commit -m "Update to ${{ inputs.version }}"
           # AUR's default branch is master; a local `main` needs the explicit
           # refspec or the push is silently accepted into the wrong ref.
           git push origin HEAD:master
+
+          # Confirm the remote actually moved. A push that resolves to a no-op
+          # exits 0, and this workflow has already reported success once while
+          # publishing nothing.
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git ls-remote origin refs/heads/master | cut -f1)"
+          if [ "${local_sha}" != "${remote_sha}" ]; then
+            echo "::error::push did not land - local ${local_sha} but remote master is ${remote_sha:-<empty>}"
+            exit 1
+          fi
+          echo "published ${local_sha} to AUR master"
 
       - name: Dry run notice
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
The v0.2.0 AUR publish **reported success and produced a 404 package**.

```
warning: You appear to have cloned an empty repository.
No change to publish.
```

## Cause

The AUR repo for a never-published package is empty, so the copied `PKGBUILD` and `.SRCINFO` are **untracked**. `git diff --quiet` compares tracked files only — it saw nothing, printed "No change to publish", and exited 0. The workflow went green having pushed nothing.

This would silently skip the first publish of *any* new AUR package. It only looks correct on updates, where the files already exist as tracked.

## Reproduced, not reasoned about

Against a real empty bare repo with both files present:

```
OLD: git diff --quiet before staging   -> "No change to publish"  (wrong)
NEW: stage, then git status --porcelain -> would commit           (correct)
```

`git status --porcelain` counts untracked and staged entries, and works in a repo with no HEAD to diff against.

## Also: verify the push landed

A push that resolves to a no-op exits 0. This workflow has now demonstrated once that "reported success, published nothing" is a state it can reach, so the exit code alone isn't evidence. It now compares `HEAD` against `git ls-remote` and fails loudly if the remote didn't move.

## Wider point

Three bugs in this workflow have now shared one shape: a step that succeeds while accomplishing nothing — `ssh-keyscan` returning no keys and exiting 0, `git diff` not seeing untracked files, and `git push` no-oping. Each reported success. The external check (`curl` the AUR RPC) is what caught it, not CI.