### PR TITLE
fix(aur): do not fail a successful publish when AUR drops the connection

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -155,13 +155,32 @@ jobs:
           # Confirm the remote actually moved. A push that resolves to a no-op
           # exits 0, and this workflow has already reported success once while
           # publishing nothing.
+          #
+          # Retried, because AUR closes the SSH connection immediately after a
+          # push: the first attempt at this got "Connection closed by ... port
+          # 22" and failed a run whose push had in fact succeeded. Reporting
+          # failure on a successful publish is its own hazard -- it invites a
+          # re-run, and re-running a publish is not always harmless.
           local_sha="$(git rev-parse HEAD)"
-          remote_sha="$(git ls-remote origin refs/heads/master | cut -f1)"
-          if [ "${local_sha}" != "${remote_sha}" ]; then
-            echo "::error::push did not land - local ${local_sha} but remote master is ${remote_sha:-<empty>}"
+          remote_sha=""
+          for attempt in 1 2 3 4 5; do
+            remote_sha="$(git ls-remote origin refs/heads/master 2>/dev/null | cut -f1)"
+            [ -n "${remote_sha}" ] && break
+            echo "  ls-remote attempt ${attempt} got nothing (AUR often drops the connection after a push); retrying"
+            sleep $((attempt * 5))
+          done
+
+          if [ -z "${remote_sha}" ]; then
+            # Could not reach AUR to confirm. The push itself reported success,
+            # so do NOT fail -- say plainly that it is unconfirmed and let the
+            # package page be the check.
+            echo "::warning::could not reach AUR to confirm the push landed; git push reported success. Verify at https://aur.archlinux.org/packages/thinkutils"
+          elif [ "${local_sha}" != "${remote_sha}" ]; then
+            echo "::error::push did not land - local ${local_sha} but remote master is ${remote_sha}"
             exit 1
+          else
+            echo "published ${local_sha} to AUR master"
           fi
-          echo "published ${local_sha} to AUR master"
 
       - name: Dry run notice
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
The v0.2.0 AUR publish **succeeded** and the workflow reported **failure**:

```
[master (root-commit) 6785b0b] Update to 0.2.0
 * [new branch]      HEAD -> master        <- the push landed
Connection closed by 209.126.35.78 port 22 <- the verification step failed
fatal: Could not read from remote repository.
```

`aur.archlinux.org/packages/thinkutils` shows **`thinkutils 0.2.0-1`**. The package is live. What failed was the `ls-remote` check I added one commit earlier — AUR closes the SSH connection immediately after accepting a push, so the second connection was refused.

## Why this direction matters

Reporting failure on a successful publish isn't the harmless version of this mistake. It invites a re-run, and re-running a publish is not always harmless.

## Change

- Retry `ls-remote` with backoff
- If AUR still can't be reached: **warn**, naming the package page, rather than fail. `git push` already reported success, and an unreachable remote is not evidence the push didn't land.
- A genuine mismatch — remote readable and disagreeing — still fails.

## The general point

A verification step has to distinguish **"this did not work"** from **"I could not tell"**. This one conflated them, and so produced a false negative on the very publish it was written to protect.

That's the mirror of the bug it was added for, three commits ago: `git diff` not seeing untracked files meant the workflow reported success having pushed nothing. Same workflow, opposite error, both from a check that couldn't tell the difference between an outcome and an absence of information.