### PR TITLE
fix(linux): avoid Wayland EGL startup failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ sudo dpkg -i thinkutils_*.deb
 sudo rpm -i thinkutils-*.rpm
 ```
 
+### Wayland compatibility
+
+ThinkUtils automatically uses WebKitGTK's compatibility renderer on Wayland to
+avoid startup failures from unsupported DMA-BUF/EGL configurations. To retain
+WebKitGTK's default renderer for troubleshooting, launch with:
+
+```bash
+THINKUTILS_SKIP_WAYLAND_WORKAROUND=1 thinkutils
+```
+
 ## Features
 
 ### 🏠 Home Dashboard

--- a/src-tauri/src/linux_webkit.rs
+++ b/src-tauri/src/linux_webkit.rs
@@ -1,0 +1,78 @@
+use std::ffi::OsStr;
+
+const DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+const SKIP_WORKAROUND_ENV: &str = "THINKUTILS_SKIP_WAYLAND_WORKAROUND";
+
+pub fn apply_wayland_renderer_workaround() {
+    if !should_apply_workaround(
+        std::env::var_os("XDG_SESSION_TYPE").as_deref(),
+        std::env::var_os("WAYLAND_DISPLAY").as_deref(),
+        std::env::var_os(DMABUF_RENDERER_ENV).as_deref(),
+        std::env::var_os(SKIP_WORKAROUND_ENV).as_deref(),
+    ) {
+        return;
+    }
+
+    // This must run before Tauri initializes WebKitGTK. It selects WebKit's
+    // fallback renderer when the DMA-BUF/EGL path is unavailable on Wayland.
+    std::env::set_var(DMABUF_RENDERER_ENV, "1");
+    eprintln!("[thinkutils] Wayland detected; enabled WebKitGTK EGL compatibility mode");
+}
+
+fn should_apply_workaround(
+    session_type: Option<&OsStr>,
+    wayland_display: Option<&OsStr>,
+    renderer_override: Option<&OsStr>,
+    skip_workaround: Option<&OsStr>,
+) -> bool {
+    let is_wayland = session_type
+        .and_then(OsStr::to_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+        || wayland_display.is_some();
+
+    is_wayland && renderer_override.is_none() && skip_workaround.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_apply_workaround;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn applies_to_wayland_sessions_without_an_override() {
+        assert!(should_apply_workaround(
+            Some(OsStr::new("wayland")),
+            None,
+            None,
+            None,
+        ));
+        assert!(should_apply_workaround(
+            None,
+            Some(OsStr::new("wayland-0")),
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn leaves_x11_and_user_choices_unchanged() {
+        assert!(!should_apply_workaround(
+            Some(OsStr::new("x11")),
+            None,
+            None,
+            None,
+        ));
+        assert!(!should_apply_workaround(
+            Some(OsStr::new("wayland")),
+            None,
+            Some(OsStr::new("0")),
+            None,
+        ));
+        assert!(!should_apply_workaround(
+            Some(OsStr::new("wayland")),
+            None,
+            None,
+            Some(OsStr::new("1")),
+        ));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,12 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(target_os = "linux")]
+mod linux_webkit;
+
 fn main() {
+    #[cfg(target_os = "linux")]
+    linux_webkit::apply_wayland_renderer_workaround();
+
     thinkutils_lib::run()
 }


### PR DESCRIPTION
## Summary

- detect Wayland before Tauri/WebKitGTK initialization
- select WebKitGTK's DMA-BUF fallback when no user renderer override is present, avoiding the `EGL_BAD_PARAMETER` startup abort reported on Arch/Plasma Wayland
- preserve explicit `WEBKIT_DISABLE_DMABUF_RENDERER` choices and provide `THINKUTILS_SKIP_WAYLAND_WORKAROUND=1` as an opt-out
- document the behavior and cover Wayland, X11, override, and opt-out decisions

Closes #12.

## Why this is early startup code

The renderer environment must be set before `thinkutils_lib::run()` initializes Tauri and creates the WebKitGTK webview. Applying it in setup hooks would be too late for the failing EGL display initialization.

## Validation

Executed in a clean Debian 12 ARM64 Linux container with the same WebKitGTK/GTK packages required by CI:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — **136 passed, 0 failed**, including 2 new Linux Wayland decision tests
- `git diff --check`

I could not reproduce a physical Plasma/Wayland compositor inside the headless container, so the PR remains draft for a reporter/maintainer smoke test on the affected desktop.
